### PR TITLE
Adding nuru binary direct to /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@ instructions for your device below:
 curl -O -L https://github.com/AvicennaJr/Nuru/releases/download/v0.1.0/nuru_linux_amd64_v0.1.0.tar.gz
 ```
 
- - Extract the file:
+ - Extract the file to make global available:
 
 ```
-tar -xzvf nuru_linux_amd64_v0.1.0.tar.gz
+sudo tar -C /usr/local/bin -xzvf nuru_linux_amd64_v0.1.0.tar.gz
 ```
- - Add it to your $PATH:
 
-```
-cp nuru $HOME/bin
-```
  - Confirm installation with:
 
 ```


### PR DESCRIPTION
command ```cp nuru $HOME/bin``` will actually change nuru binary name to bin name instead of copying nuru binary to /$HOME/bin/ folder so will look like /$HOME/bin/nuru, since /$HOME/bin is not in path yet also will make things complicate so to solve this you can direct extract nuru binary to /usr/local/bin by using a command below

```
sudo tar -C /usr/local/bin -xzvf nuru_linux_amd64_v0.1.0.tar.gz
```